### PR TITLE
Feature/add amdvlk

### DIFF
--- a/modules/system/default.nix
+++ b/modules/system/default.nix
@@ -2,6 +2,7 @@
 {
   imports =
   [
+    ./hardware/amdvlk.nix
     ./hardware/bluetooth.nix
     ./hardware/kernel.nix
     ./hardware/printing.nix

--- a/modules/system/hardware/amdvlk.nix
+++ b/modules/system/hardware/amdvlk.nix
@@ -1,9 +1,12 @@
 {pkgs, ...}:
 {
+  environment.systemPackages = with pkgs;
+  [
+    vulkan-tools
+  ];
   hardware.graphics =
   {
     extraPackages = [pkgs.amdvlk];
-    extraPackages32 = [pkgs.driversi686Linux.amdvlk];
   };
   environment.variables =
   {

--- a/modules/system/hardware/amdvlk.nix
+++ b/modules/system/hardware/amdvlk.nix
@@ -1,0 +1,12 @@
+{pkgs, ...}:
+{
+  hardware.graphics =
+  {
+    extraPackages = [pkgs.amdvlk];
+    extraPackages32 = [pkgs.driversi686Linux.amdvlk];
+  };
+  environment.variables =
+  {
+    AMD_VULKAN_ICD = "RADV";
+  };
+}


### PR DESCRIPTION
This PR aims to add AMDVLK as an optional driver, in order to cover edge cases like Dragons Dogma 2. 

RADV is still being used as the default driver for the system, through the AMD_VULKAN_ICD environment variable.